### PR TITLE
chore: Add VS Code dev-containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php
+{
+	"name": "PHP",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/php:1-8.4-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8000
+	],
+	"features": {
+		"ghcr.io/devcontainers-extra/features/composer:1": {}
+	}
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,26 @@ composer install
 php artisan key:generate
 php artisan serve
 ```
+
+Or using Visual Studio Code dev-containers ([requirements and setup-guide](https://code.visualstudio.com/docs/devcontainers/containers#_installation)):
+
+First, set-up the env variables and the database:
+
+```bash
+cp .env.development .env
+docker compose up -d
+```
+
+After the database is up and running, you can start the dev-container from your VS Code interface. 
+
+Start VS Code, run the Dev Containers: Open Folder in Container... command from the Command Palette. For more information, see [here](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container).
+
+After the dev-container is running, you need to run the following inside the container to get started:
+
+```bash
+composer install
+php artisan key:generate
+php artisan serve
+```
+
+After completing the final command above, the API should be available to you at `localhost:8000`.


### PR DESCRIPTION
Adds a simple VS Code dev-container configuration that runs PHP 8.4 and has composer installed. 

Allows for simple development via Visual Studio Code and the dev-container feature.

For more information, see [here](https://code.visualstudio.com/docs/devcontainers/containers) and [here](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container).

We could investigate using postCreateCommand to run post-create tooling like `composer install`, `php artisan key:generate` and  `php artisan migrate` in the future, but this is not implemented as of now. 