### PR TITLE
fix: handle case where app key is generated after seeding

### DIFF
--- a/scripts/initialise-dev-container.sh
+++ b/scripts/initialise-dev-container.sh
@@ -1,16 +1,7 @@
 #!/usr/bin/env bash
 
-seeded=0
-
-function setup_composer() {
-    echo 'Running composer install to make sure dependencies are installed and up to date'
-    composer install
-}
-
-function seed_database() {
-    echo 'Trying to seed database, in a fail-safely manner'
-    # Call migration status command until we get a response, abort if waiting for more than 30 tries
-    # local status=$(php artisan migrate:status)
+function await_database() {
+    # Wait for the database to be available, retrying every 2 seconds, up to 30 times
     local status=""
     local tries=1
     while [[ !($status == *"Ran"* || $status == *"Pending"* || $status == *"table not found"*) && $tries -le 30 ]]; do
@@ -21,37 +12,56 @@ function seed_database() {
         ((tries++))
     done
 
-    if [[ $tries -gt 30 ]]; then
-        echo "Failed to get existing migration status after 30 attempts, aborting database initialization"
-        return
-    fi
-
-    echo "$status"
-
-    # Check if any migrations have status of "Ran"
-    # If so, we assume the database is already seeded
-    if [[ $status == *"Ran"* ]]; then
-        echo 'Some migrations have already been run, assuming database have already been seeded, skipping'
-        # Make sure we see indication of "Pending" migrations
-    elif [[ $status == *"Pending"* || $status == *"table not found"* ]]; then
-        echo 'No migrations seem to have have been run, migrating and seeding database'
-        php artisan migrate:fresh --seed
-        seeded=1
-    fi
+    return $((tries > 30 ? 1 : 0))
 }
 
-function generate_app_key() {
-    if [[ $seeded -eq 0 ]]; then
-        echo 'No database seeding was done, assuming application key has already been generated'
+function is_fresh_database() {
+    local status=$(php artisan migrate:status 2>/dev/null || echo "")
+    echo "$status"
+
+    if [[ $status == *"table not found"* ]]; then
+        return 0
+    elif [[ $status == *"Ran"* ]]; then
+        return 1
+    elif [[ $status == *"Pending"* ]]; then
+        return 0
+    fi
+
+    return 1 # Fail safely
+}
+
+function setup_laravel() {
+    is_fresh_database
+    fresh_database=$?
+
+    if [[ $fresh_database > 0 ]]; then
+        echo 'Database is not fresh, skipping application key generation and seeding'
+        return 1
     fi
 
     echo 'Generating application key'
     php artisan key:generate
+
+    echo 'Trying to seed database, in a fail-safely manner'
+    echo 'No migrations seem to have have been run, migrating and seeding database'
+    php artisan migrate:fresh --seed
 }
 
-setup_composer
-seed_database
-generate_app_key
+function main_setup() {
+    echo 'Running composer install to make sure dependencies are installed and up to date'
+    composer install
+
+    await_database
+    await_result=$?
+
+    if [[ $await_result == 0 ]]; then
+        setup_laravel
+    else
+        echo 'Database is not available, skipping application setup'
+    fi
+}
+
+main_setup
 
 echo 'Automatic initialization of dev container is done, check out project README.md for more information on manual steps and general development information'
 


### PR DESCRIPTION
Turns out information about `APP_KEY` not being used for database encryption was wrong, so tweaking init script to make sure seeding happens after key rotation.