### PR TITLE
feat: Add vscode xdebug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+        }
+    ]
+}


### PR DESCRIPTION
When using Visual Studio Code and Dev-containers, this PR adds a config that automatically configures debug in your VS Code env. 

Steps to use:
1. Start your dev-container as normal
2. Start debugging with F5 (select "Listen for Xdebug")
3. Open a terminal in the dev-container and type "php artisan serve". 

You should now see the debugger being active. 

![image](https://github.com/user-attachments/assets/45761f38-cd11-485c-b71b-33352c02b928)
