### PR TITLE
chore: add pre-commit command

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,44 @@
+
+# How to develop on Wannabe5-Core
+
+## Configure pre-commits
+
+Run the following command to add your pre-commit config:
+```bash
+php artisan app:precommit 
+```
+
+## Linting
+
+We use Laravel Lint, and your pull-request will not be accepted by our project automations without running this before commiting. 
+
+If the pre-commit (Note: Does not exist yet!) fails, run this before commiting:
+
+```bash
+./vendor/bin/pint
+```
+
+## Generate OpenAPI documentation
+
+This needs to be done before a pull-request is approved.
+
+```bash
+php artisan scramble:export
+```
+
+## Creating a new model
+
+We want to focus on using Resources, Requests and lean Controllers. Place validation in Requests and create Resources for all return objects. 
+
+```bash
+php artisan make:request <ModelName>Request
+php artisan make:resource <ModelName>Resource
+```
+
+Refer to the Laravel documentation on how to use [Resources](https://laravel.com/docs/12.x/eloquent-resources) and [Requests](https://laravel.com/docs/12.x/validation#form-request-validation) in your controllers.
+
+Also consider creating a Factory to be able to seed the model.
+
+```bash
+php artisan make:factory <ModelName>Factory
+```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ composer install
 php artisan key:generate
 php artisan migrate:fresh --seed
 php artisan serve
+php artisan app:precommit
 ```
 
 > [!TIP]

--- a/app/Console/Commands/precommit.php
+++ b/app/Console/Commands/precommit.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class precommit extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:precommit';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Writes current pre-commit config to .git/hooks/pre-commit';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $precommitConfig = '
+            #!/bin/bash
+            ./vendor/bin/pint
+            php artisan scramble:export';
+        if (file_put_contents('.git/hooks/pre-commit', $precommitConfig) !== false) {
+            echo 'Pre-commit config written successfully.'.PHP_EOL;
+        } else {
+            echo 'Failed to write pre-commit config.'.PHP_EOL;
+        }
+    }
+}

--- a/scripts/initialise-dev-container.sh
+++ b/scripts/initialise-dev-container.sh
@@ -45,6 +45,7 @@ function setup_laravel() {
     echo 'Trying to seed database, in a fail-safely manner'
     echo 'No migrations seem to have have been run, migrating and seeding database'
     php artisan migrate:fresh --seed
+    php artisan app:precommit
 }
 
 function main_setup() {


### PR DESCRIPTION
Fixes #15 

To avoid adding another dependency to the dev env, I just created a very simple artisan command that writes the pre-commit script to the correct file. 

Run the command like this:
```
php artisan app:precommit
```