### PR TITLE
fix: unique check on pages

### DIFF
--- a/app/Http/Requests/PageRequest.php
+++ b/app/Http/Requests/PageRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PageRequest extends FormRequest
 {
@@ -23,11 +24,16 @@ class PageRequest extends FormRequest
     {
         return [
             'title' => 'required', // Page title is required
-            'content' => 'json|required', // Page content is required
+            'content' => 'required|json|', // Page content is required
             // 'event_id' => 'required|integer', // Event ID is required and must be an integer
-            'author_id' => 'uuid|required', // User ID is required and must be a UUID
+            'author_id' => 'required|uuid|exists:users,id', // User ID is required and must be a UUID
             'public' => 'boolean',
-            'slug' => 'required|alpha_dash:ascii|unique:pages,slug,'.$this->slug.',slug', // Slug is required and must contain only ASCII characters and underscores/dashes
+            // Slug is required and must contain only ASCII characters and underscores/dashes
+            'slug' => [
+                'required',
+                'alpha_dash:ascii',
+                Rule::unique('pages', 'slug')->ignore($this->page),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/UserProfileRequest.php
+++ b/app/Http/Requests/UserProfileRequest.php
@@ -26,7 +26,12 @@ class UserProfileRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'nickname' => 'required|string|max:50|unique:user_profiles,nickname,'.$this->profile->id.',id',
+            'nickname' => [
+                'required',
+                'string',
+                'max:50',
+                Rule::unique('user_profiles', 'nickname')->ignore($this->profile),
+            ],
             'birthdate' => [
                 'required',
                 Rule::date()->format('Y-m-d'),

--- a/openapi.json
+++ b/openapi.json
@@ -653,7 +653,8 @@
                         "description": "User ID is required and must be a UUID"
                     },
                     "slug": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Slug is required and must contain only ASCII characters and underscores/dashes"
                     }
                 },
                 "required": [


### PR DESCRIPTION
The unique check on pages did not work, `$this->slug` will be the user input, and so it will always ignore.
Laravel [documentation](https://laravel.com/docs/12.x/validation#rule-unique) is also clear this will make it vulnerable to an SQL injection attack.

Added a few tests to test basic validation.

Nickname in user_profiles did not have the same issue, but would have failed if we ever have a endpoint to create new profiles. `$this->profile` will be null, and so `$this->profile->id `will fail.