### PR TITLE
feat: move postgres-variables from compose to .env.

### DIFF
--- a/.env.ci.testing
+++ b/.env.ci.testing
@@ -1,10 +1,16 @@
 # php artisan key:generate
 APP_KEY=base64:nfTdlWswyvfctT6YNgk92bZaKWs5HfhdcyIXWmJUcuk=
 
-# Must match compose.yml -> db -> environment
+# devcontainer
 DB_USERNAME=laravel
 DB_DATABASE=wannabe5
 DB_PASSWORD=mydevelopmentexample
+
+
+# db (loading variables from dev_container, so no need to change here)
+POSTGRES_USER=${DB_USERNAME}
+POSTGRES_DB=${DB_DATABASE}
+POSTGRES_PASSWORD=${DB_PASSWORD}
 
 TELESCOPE_ENABLED=true
 # Log to stdout/stderr

--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,16 @@ APP_ENV=local
 # Intended for use in docker containers, meaning `php artisan serve` will accept traffic from any source
 SERVER_HOST=0.0.0.0
 
-# Must match compose.yml -> db -> environment
+# devcontainer
 DB_HOST=db
 DB_USERNAME=laravel
 DB_DATABASE=wannabe5
 DB_PASSWORD=mydevelopmentexample
+
+# db (loading variables from dev_container, so no need to change here)
+POSTGRES_USER=${DB_USERNAME}
+POSTGRES_DB=${DB_DATABASE}
+POSTGRES_PASSWORD=${DB_PASSWORD}
 
 TELESCOPE_ENABLED=true
 # Log to stdout/stderr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
           fetch-depth: 1
       - name: Setup database using docker
         run: |
+          cp .env.ci.testing .env
           docker compose -f compose.yml up db -d
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -25,7 +26,6 @@ jobs:
         run: composer install -n --prefer-dist
       - name: Prepare Laravel Application
         run: |
-          cp .env.ci.testing .env
           php artisan key:generate
           php artisan migrate --force -n
       - name: Run tests

--- a/compose.yml
+++ b/compose.yml
@@ -15,9 +15,6 @@ services:
     image: postgres
     ports:
       - 127.0.0.1:5432:5432
-    environment:
-      POSTGRES_USER: laravel
-      POSTGRES_DB: wannabe5
-      POSTGRES_PASSWORD: mydevelopmentexample
+    env_file: .env
     volumes:
       - ./scripts/create-test-db.sh:/docker-entrypoint-initdb.d/create-test-db.sh


### PR DESCRIPTION
Moving postgres-variables, such as user/db/password, from compose.yml to .env for better userability/readness